### PR TITLE
build: update code to use Atala PRISM 1.3.2 SDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.rootsid.wal"
-version = "1.0.0"
+version = "1.0.1-SNAPSHOT"
 
 repositories {
     mavenLocal()
@@ -43,27 +43,27 @@ dependencies {
     // Fixes a build issue
     implementation("com.soywiz.korlibs.krypto:krypto-jvm:2.0.6")
 
-    implementation("com.rootsid.wal:wal-library:1.0.0")
+    implementation("io.iohk.atala:prism-crypto:v1.3.2")
+
+    implementation("io.iohk.atala:prism-identity:v1.3.2")
+
+    implementation("io.iohk.atala:prism-credentials:v1.3.2")
+
+    implementation("io.iohk.atala:prism-api:v1.3.2")
+
+    implementation("com.rootsid.wal:wal-library:1.0.1-SNAPSHOT")
 
     implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.4")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0-native-mt")
 
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
     implementation("com.github.ajalt.mordant:mordant:2.0.0-beta3")
 
-    implementation("io.iohk.atala:prism-crypto:1.3.0")
-
-    implementation("io.iohk.atala:prism-identity:1.3.0")
-
-    implementation("io.iohk.atala:prism-credentials:1.3.0")
-
-    implementation("io.iohk.atala:prism-api:1.3.0")
-
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
 
-    implementation("org.litote.kmongo:kmongo:4.4.0")
+    implementation("org.litote.kmongo:kmongo:4.5.0")
 
     implementation("org.didcommx:didcomm:0.3.0")
 

--- a/src/test/kotlin/CommandTest.kt
+++ b/src/test/kotlin/CommandTest.kt
@@ -1,6 +1,8 @@
+@file:OptIn(ExperimentalCli::class)
 import com.mongodb.client.MongoDatabase
 import com.rootsid.wal.library.*
 import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.File
@@ -609,17 +611,17 @@ class CommandTest {
         val keyId = "master1"
         val keyPurpose = "master"
         // Wallet and dids
-        assertDoesNotThrow("New wallet") {
+        assertDoesNotThrow("addKeyTest - New wallet") {
             newParser().parse(arrayOf("new-wallet", walletName))
         }
-        assertDoesNotThrow("New issuer DID") {
+        assertDoesNotThrow("addKeyTest - New issuer DID") {
             newParser().parse(arrayOf("new-did", walletName, issuerDidAlias, "-i"))
         }
-        assertDoesNotThrow("Publish issuer DID") {
+        assertDoesNotThrow("addKeyTest - Publish issuer DID") {
             newParser().parse(arrayOf("publish-did", walletName, issuerDidAlias))
         }
         // New Key
-        assertDoesNotThrow("New key") {
+        assertDoesNotThrow("addKeyTest - New key") {
             newParser().parse(
                 arrayOf(
                     "add-key",


### PR DESCRIPTION
Atala PRISM 1.3.2 SDK has introduced breaking changes. PrismKeyType no longer exists, so key types are expressed with MasterKeyUsage, IssuingKeyUsage, and RevocationKeyUsage objects.