### PR TITLE
unit tests are failing when upgrading to 1.0.2 wal-lib and 1.4.1 pris…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,15 +44,15 @@ dependencies {
     // Fixes a build issue
     implementation("com.soywiz.korlibs.krypto:krypto-jvm:2.0.6")
 
-    implementation("io.iohk.atala:prism-crypto:v1.3.3")
+    implementation("io.iohk.atala:prism-crypto:v1.4.1")
 
-    implementation("io.iohk.atala:prism-identity:v1.3.3")
+    implementation("io.iohk.atala:prism-identity:v1.4.1")
 
-    implementation("io.iohk.atala:prism-credentials:v1.3.3")
+    implementation("io.iohk.atala:prism-credentials:v1.4.1")
 
-    implementation("io.iohk.atala:prism-api:v1.3.3")
+    implementation("io.iohk.atala:prism-api:v1.4.1")
 
-    implementation("com.rootsid.wal:wal-library:1.0.1-SNAPSHOT")
+    implementation("com.rootsid.wal:wal-library:1.0.2")
 
     implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.4")
 

--- a/src/main/kotlin/Command.kt
+++ b/src/main/kotlin/Command.kt
@@ -242,11 +242,11 @@ class ResolvePrismDid : Subcommand("resolve-prism-did", "Resolve PRISM did and s
         val dataModel = getDidDocument(did)
         println(green("-- $name --"))
         println("DID document")
-        if (w3c) {
-            println(getDidDocumentW3C(did))
-        } else {
+//        if (w3c) {
+//            println(getDidDocumentW3C(did))
+//        } else {
             println(dataModel.didData.toProto().encodeToJsonString())
-        }
+//        }
     }
 }
 


### PR DESCRIPTION
Trying this upgrade causes all tests to fail with UNAVAILABLE, which is the same as what we see in RootsWallet, using wal-lib 2.0.1 w/ prism 1.4.1